### PR TITLE
Add `npm install` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Returns an object containing information about the samples.
 
 ## Local Development
 
-The package is built with `npm run build:pkg`.
+1. Install dependencies with `npm install`.
+
+2. The package is built with `npm run build:pkg`.
 
 [samples.generative.fm]: https://samples.generative.fm


### PR DESCRIPTION
I looked at https://github.com/generative-music/stream.generative.fm/issues/2 and noticed that `npm install` was missing from the "Local Development" section of this repository.